### PR TITLE
feat: allcars/all API 추가

### DIFF
--- a/backend/src/routes/cars.js
+++ b/backend/src/routes/cars.js
@@ -2,11 +2,10 @@ const express = require("express");
 const router = express.Router();
 const Car = require("../models/carModel");
 
-// 차종 검색
-router.get("/search/:model", async (req, res) => {
+// 모든 차량 데이터 가져오기
+router.get("/all", async (req, res) => {
   try {
-    const { model } = req.params;
-    const cars = await Car.find({ model: new RegExp(model, "i") });
+    const cars = await Car.find();
     res.json({ cars });
   } catch (error) {
     console.error(error);
@@ -14,19 +13,8 @@ router.get("/search/:model", async (req, res) => {
   }
 });
 
-// 차량 정보 조회 (프론트엔드에서 호출할 때 차량 ID를 이용하여)
-router.get("/cars/:model", async (req, res) => {
-  try {
-    const { model } = req.params;
-    const cars = await Car.find({ model: new RegExp(model, "i") });
-    res.json({ cars });
-  } catch (error) {
-    console.error(error);
-    res.status(500).json({ error: "Internal server error" });
-  }
-});
+//--------------------------------------------------------------위에 1개만 참고!! http://localhost:3000/allcars/all 아래 소스들은 무시!!
 
-//--------------------------------------------------------------우선 위에 2개만 참고!! 아래 소스들은 무시!!
 // 차량 목록 조회
 router.get("/cars", (req, res) => {
   Car.find({}, (err, cars) => {

--- a/backend/src/routes/cars.js
+++ b/backend/src/routes/cars.js
@@ -2,23 +2,54 @@ const express = require("express");
 const router = express.Router();
 const Car = require("../models/carModel");
 
-// 샘플 데이터 조회
-router.get("/cars", (req, res) => {
-  console.log("GET request received for /cars");
-  const sampleData = {
-    cars: [
-      { model: "Car 1", brand: "Brand 1" },
-      { model: "Car 2", brand: "Brand 2" },
-      { model: "Car 3", brand: "Brand 3" },
-    ],
-  };
-  // JSON 형식으로 데이터 응답
-  res.json(sampleData);
+// 차종 검색
+router.get("/search/:model", async (req, res) => {
+  try {
+    const { model } = req.params;
+    const cars = await Car.find({ model: new RegExp(model, "i") });
+    res.json({ cars });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: "Internal server error" });
+  }
 });
 
-router.get("/", (req, res) => {
-  console.log("GET request received for /");
-  res.send("Hello world");
+// 차량 정보 조회 (프론트엔드에서 호출할 때 차량 ID를 이용하여)
+router.get("/cars/:model", async (req, res) => {
+  try {
+    const { model } = req.params;
+    const cars = await Car.find({ model: new RegExp(model, "i") });
+    res.json({ cars });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+//--------------------------------------------------------------우선 위에 2개만 참고!! 아래 소스들은 무시!!
+// 차량 목록 조회
+router.get("/cars", (req, res) => {
+  Car.find({}, (err, cars) => {
+    if (err) {
+      console.error(err);
+      res.status(500).json({ error: "Internal server error" });
+    } else {
+      res.json({ cars });
+    }
+  });
+});
+
+// 차량 상세 정보 조회
+router.get("/cars/:carId", (req, res) => {
+  const { carId } = req.params;
+  Car.findById(carId, (err, car) => {
+    if (err) {
+      console.error(err);
+      res.status(500).json({ error: "Internal server error" });
+    } else {
+      res.json({ car });
+    }
+  });
 });
 
 // 새로운 차량 추가
@@ -45,18 +76,6 @@ router.post("/cars/register", (req, res) => {
       res.status(500).json({ error: "Failed to add a new car" });
     });
 });
-
-// 차량 목록 조회
-// router.get("/cars", (req, res) => {
-//   Car.find({}, (err, cars) => {
-//     if (err) {
-//       console.error(err);
-//       res.status(500).json({ error: "Internal server error" });
-//     } else {
-//       res.json({ cars });
-//     }
-//   });
-// });
 
 // 차량 상세 정보 조회
 router.get("/cars/:carId", (req, res) => {

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -4,6 +4,7 @@ const cors = require("cors"); // CORS 미들웨어 추가
 const app = express();
 const carsRouter = require("./routes/cars");
 const bookingsRouter = require("./routes/booking");
+const Car = require("./models/carModel"); // Car 모델 import 지워야할것들
 
 connectDB();
 
@@ -17,6 +18,7 @@ app.use(cors());
 app.use("/", carsRouter);
 app.use("/cars", carsRouter);
 app.use("/booking", bookingsRouter);
+app.use("/allcars", carsRouter); // /all 엔드포인트 추가
 
 const PORT = 3000;
 app.listen(PORT, () => {


### PR DESCRIPTION
- 차량 데이터 요청시 DB에 저장된 차량 정보데이터 전부 보내도록 설정했습니다.
EX) car_id: 001, Model: 쏘렌토, mileage: 0, year:2024, fuel:휘발유, details:중형 SUV ... 20번 데이터까지 출력

- 말씀해주신 차량 id도 간략하게 `001` 이런 식으로 변경하였습니다.
EX) {
    _id: ObjectId('65a2ad8950c79d2440effe32'),
    model: '니로 EV',
    carId: '020',
    mileage: 0,
    year: 2018,
    fuel: '전기',
    details: '중형 SUV',
    __v: 0
  }

rentCarDB의 cars컬렉션에 EX)와 같이 data가 저장되어 있으며, _id 필드는 MongoDB에서 data를 생성할 때 자동으로 생성되는 필드이고, __v 필드는 Mongoose에서 버전 관리를 위해 자동 생성되는 필드이기에 다음 두 필드에 대해서는 의식하지 않고 id값은 carId 필드를 활용하여 진행하면 될 것 같습니다.

확인해보시고 피드백 요청 부탁드립니다.